### PR TITLE
add ShellSession to make newlines render properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,26 @@ https://github.com/slaclab/rogue
 
 To checkout rogue submodule:
 
-> git submodule init
-> git sudmodule update
 
+```ShellSession
+git submodule init
+git sudmodule update
+```
 See rogue/Readme files for rogue build instructions.
 
 To build this example software you must first setup the environment. A
 template file setup_template.csh is provided as an example. To 
 use this file execute the following in your tcsh:
 
-> source setup_template.csh
+```ShellSession
+source setup_template.csh
+```
 
 If using a different shell the equivelent setup file for that shell 
 must be created.
 
 Once the environment is setup you can build this software:
-> make
+```ShellSession
+make
+```
 


### PR DESCRIPTION
"git submodule init git sudmodule update" where shown on a single line. by added shellsession it shows up now correctly. So people can copy/paste quickly